### PR TITLE
[Do Not Merge] Modify in_position? method to fix inconsistencies

### DIFF
--- a/lib/puppet/provider/pam/augeas.rb
+++ b/lib/puppet/provider/pam/augeas.rb
@@ -67,12 +67,12 @@ Puppet::Type.type(:pam).provide(:augeas, :parent => Puppet::Type.type(:augeaspro
       # Would someone ever have an xpath for positioning that would include more than one [last()] ?
       # This section banks on there only ever being one [last()]...
       # We are unable to use [last()] inside the preceding-sibling block as it would always result in [1] so we do an
-      # extra call to augeas to find the last value of the matches and subtract 1 to match the proper lookup/emulate last()
+      # extra call to augeas to find the amount of matches and subtract 1 to match the proper lookup/emulate last()
       if path.include?('[last()]')
-        last_value = augopen.match(path)
-        return false if last_value.empty?
-        last_value = last_value[0].split('/').last.to_i - 1
-        path.sub!(/\[last\(\)\]/, "[#{last_value}]")
+        last_value = augopen.match(path.sub('[last()]','')).count
+        return true if last_value <= 1
+        last_value = last_value - 1
+        path.sub!('[last()]', "[#{last_value}]")
       end
       mpath = "#{resource_path}[preceding-sibling::#{path}]"
 


### PR DESCRIPTION
in_position? method wasn't working right due to issues with using following-sibling when before and preceding-sibling when after, this corrects it with new, hopefully proper assumptions.  The only item that small change didn't fix was last() which was not working for either because of the way siblings treat the last() command as it will always resolve to true on the first match in those cases.  This patch assumes that you'll never have more than one [last()] in your xpath for positioning and swaps it out with the correct final array value of augeas matches.  We use an invert boolean on 'after' positions as we will always have an empty? resolving as true if the match exists before the item we're looking for.  Whereas we'll always have empty? as false if we do a 'before' and the actual item currently exists after the line we're trying to match.

-- I still need to complete the unit tests for this.  But this should be a working solution unless some side effects or conflicts can be presented.

this is a patch in reference to https://github.com/hercules-team/augeasproviders_pam/issues/10
