### PR TITLE
Drop Puppet 5 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,6 @@
     }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": ">= 5.0.0 < 7.0.0" }
+    { "name": "puppet", "version_requirement": ">= 6.1.0 < 7.0.0" }
   ]
 }


### PR DESCRIPTION
Included in https://github.com/voxpupuli/puppet-augeasproviders_pam/pull/30 but this deserves a changelog entry.